### PR TITLE
Update quickstart.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Installation
 
    ``pip install django-typeahead``
 
-2. Add ``bootstrap_typeahead`` to the list of ``INSTALLED_APPS`` in your ``settings.py`` file:
+2. Add ``django_typeahead`` to the list of ``INSTALLED_APPS`` in your ``settings.py`` file:
 
   .. code-block:: python
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -16,13 +16,13 @@ Installation
 
    ``pip install django-typeahead``
 
-2. Add ``bootstrap_typeahead`` to the list of ``INSTALLED_APPS`` in your ``settings.py`` file:
+2. Add ``django_typeahead`` to the list of ``INSTALLED_APPS`` in your ``settings.py`` file:
 
    .. code-block:: python
 
       INSTALLED_APPS = [
           # ...
-          'bootstrap_typeahead',
+          'django_typeahead',
       ]
 
    .. warning:: This installation instruction assumes you have ``jQuery`` and Bootstrap JS/CSS files present


### PR DESCRIPTION
'bootstrap_typeahead' does not appear to be the correct app name anymore. Docs need an update.